### PR TITLE
RLOOP-060: add required-check governance audit trail and verification

### DIFF
--- a/.github/workflows/ci-quality-gates.yml
+++ b/.github/workflows/ci-quality-gates.yml
@@ -38,10 +38,23 @@ jobs:
       - name: Type check
         run: yarn typecheck
 
-      - name: Required-check context drift guard (RLOOP-059 detect mode)
+      - name: Required-check context drift guard (RLOOP-060 detect + audit)
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           DRIFT_GUARD_POLICY: ${{ github.event_name == 'push' && 'fail' || 'warn' }}
           API_ERROR_POLICY: ${{ github.event_name == 'push' && 'fail' || 'warn' }}
         run: |
-          yarn verify:required-check-contexts:rloop058 --dry-run --branch master --policy "$DRIFT_GUARD_POLICY" --on-api-error "$API_ERROR_POLICY"
+          yarn verify:required-check-contexts:rloop058 \
+            --dry-run \
+            --branch master \
+            --policy "$DRIFT_GUARD_POLICY" \
+            --on-api-error "$API_ERROR_POLICY" \
+            --audit-file artifacts/required-check-drift-audit.json
+
+      - name: Upload required-check drift audit artifact
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: required-check-drift-audit
+          path: artifacts/required-check-drift-audit.json
+          if-no-files-found: warn

--- a/docs/BRANCH_PROTECTION_SETUP.md
+++ b/docs/BRANCH_PROTECTION_SETUP.md
@@ -17,14 +17,23 @@ Publisher check-run (workflow context değil):
 
 - `nonprod-db-canary / drift`
 
-## Drift Guard + Auto-remediation (RLOOP-059)
+## Drift Guard + Governance Audit Trail (RLOOP-060)
 
-Branch protection required context listesi ile repository workflow/job check context isimleri arasındaki drift CI içinde otomatik doğrulanır ve ops tarafında kontrollü remediation uygulanabilir.
+Branch protection required context listesi ile repository workflow/job check context isimleri arasındaki drift CI içinde otomatik doğrulanır; remediation işlemleri governance-grade audit artifact + read-after-write verification ile güvenceye alınır.
 
 - Script: `scripts/verify-required-check-contexts-rloop058.js`
 - CI integration: `CI Quality Gates` workflow step'i (detect-only)
   - `push` (master): drift varsa `fail`
   - `pull_request`: drift/API erişim problemi için `warn`
+- Audit artifact: `artifacts/required-check-drift-audit.json`
+  - içerik: `before/after` required contexts, timestamp, actor, mode, branch, plan diff, verification sonucu
+- Policy safety:
+  - default mode: `--dry-run` (non-destructive)
+  - apply mode: explicit `--apply`
+  - optional `--allowlist` / `--denylist` ile apply hedefi kısıtlanabilir
+- Read-after-write verification:
+  - `--apply` sonrası protection tekrar okunur ve expected contexts birebir doğrulanır
+  - mismatch kalırsa işlem fail olur ve actionable error basılır
 
 ### Lokal detect (non-destructive)
 
@@ -36,7 +45,8 @@ yarn verify:required-check-contexts:rloop058 \
   --repo SydneySFco/astroapp-mobile \
   --branch master \
   --policy fail \
-  --on-api-error fail
+  --on-api-error fail \
+  --audit-file artifacts/required-check-drift-audit.json
 ```
 
 ### Manual apply (controlled remediation)
@@ -51,7 +61,8 @@ yarn verify:required-check-contexts:rloop058 \
   --repo SydneySFco/astroapp-mobile \
   --branch master \
   --policy fail \
-  --on-api-error fail
+  --on-api-error fail \
+  --audit-file artifacts/required-check-drift-audit.json
 ```
 
 Optional strict mode (only canonical required-check contexts):
@@ -63,6 +74,23 @@ yarn verify:required-check-contexts:rloop058 \
   --repo SydneySFco/astroapp-mobile \
   --branch master
 ```
+
+Optional policy guardrails (safe apply):
+
+```bash
+yarn verify:required-check-contexts:rloop058 \
+  --apply \
+  --repo SydneySFco/astroapp-mobile \
+  --branch master \
+  --allowlist "CI Quality Gates / required-check / ci-quality-gates" \
+  --denylist "legacy-check-context"
+```
+
+### Rollback path
+
+1. Son başarılı audit artifact'tan `before.requiredContexts` listesini alın.
+2. Gerekirse GitHub API ile required contexts'i o listeye geri patch edin.
+3. Script'i tekrar `--dry-run` çalıştırıp drift/verification durumunu doğrulayın.
 
 ### Drift çıktısı nasıl okunur?
 

--- a/docs/RLOOP_060_NOTES.md
+++ b/docs/RLOOP_060_NOTES.md
@@ -1,0 +1,57 @@
+# RLOOP-060 — Required-check Drift Governance + Audit Trail
+
+## Objective
+Required-check drift detection/remediation akışını governance-grade traceability ve safety kontrolleriyle güçlendirmek.
+
+## Delivered
+
+- Enhanced guard script: `scripts/verify-required-check-contexts-rloop058.js`
+  - Machine-readable audit artifact output (`--audit-file`)
+  - Artifact includes:
+    - timestamp
+    - actor
+    - mode (`dry-run|apply`)
+    - branch/repo
+    - before/after required contexts
+    - drift diff + remediation plan
+    - apply + verification result
+  - Read-after-write verification (apply sonrası protection re-fetch + expected vs actual compare)
+  - Allowlist / denylist policy safety:
+    - `--allowlist`
+    - `--denylist`
+  - Dry-run default retained; apply explicit (`--apply`)
+
+- CI integration (`.github/workflows/ci-quality-gates.yml`)
+  - Detect step now emits audit JSON in non-destructive mode
+  - Audit JSON uploaded via `actions/upload-artifact@v4`
+
+- Docs / operator runbook (`docs/BRANCH_PROTECTION_SETUP.md`)
+  - Governance model
+  - Audit usage
+  - allow/deny safety controls
+  - rollback path
+
+## Validation
+
+```bash
+yarn lint
+yarn typecheck
+```
+
+## Operator snippets
+
+```bash
+# detect + audit
+yarn verify:required-check-contexts:rloop058 \
+  --dry-run \
+  --repo SydneySFco/astroapp-mobile \
+  --branch master \
+  --audit-file artifacts/required-check-drift-audit.json
+
+# explicit apply + verification
+yarn verify:required-check-contexts:rloop058 \
+  --apply \
+  --repo SydneySFco/astroapp-mobile \
+  --branch master \
+  --audit-file artifacts/required-check-drift-audit.json
+```

--- a/package.json
+++ b/package.json
@@ -10,7 +10,8 @@
     "start": "react-native start",
     "test": "jest",
     "verify:required-check-contexts:rloop058": "node scripts/verify-required-check-contexts-rloop058.js",
-    "verify:required-check-contexts:rloop059:apply": "node scripts/verify-required-check-contexts-rloop058.js --apply"
+    "verify:required-check-contexts:rloop059:apply": "node scripts/verify-required-check-contexts-rloop058.js --apply",
+    "verify:required-check-contexts:rloop060:audit": "node scripts/verify-required-check-contexts-rloop058.js --dry-run --audit-file artifacts/required-check-drift-audit.json"
   },
   "dependencies": {
     "@react-native/new-app-screen": "0.84.0",

--- a/scripts/verify-required-check-contexts-rloop058.js
+++ b/scripts/verify-required-check-contexts-rloop058.js
@@ -18,7 +18,13 @@ function parseArgs(argv) {
       continue;
     }
 
-    args[key] = next;
+    if (args[key] === undefined) {
+      args[key] = next;
+    } else if (Array.isArray(args[key])) {
+      args[key].push(next);
+    } else {
+      args[key] = [args[key], next];
+    }
     i += 1;
   }
 
@@ -27,6 +33,15 @@ function parseArgs(argv) {
 
 function normalize(value) {
   return value.trim().replace(/^['"]|['"]$/g, '');
+}
+
+function toList(value) {
+  if (!value) return [];
+  const raw = Array.isArray(value) ? value : [value];
+  return raw
+    .flatMap((item) => String(item).split(','))
+    .map((item) => item.trim())
+    .filter(Boolean);
 }
 
 function inferOwnerRepo(explicitRepo, explicitOwner, explicitRepoName) {
@@ -70,7 +85,7 @@ async function githubRequestJson(url, method, token, body) {
       Accept: 'application/vnd.github+json',
       Authorization: `Bearer ${token}`,
       'X-GitHub-Api-Version': '2022-11-28',
-      'User-Agent': 'astroapp-rloop059-required-check-autofix',
+      'User-Agent': 'astroapp-rloop060-required-check-governance-audit',
     },
     body: body ? JSON.stringify(body) : undefined,
   });
@@ -246,10 +261,16 @@ function dedupe(list) {
   return Array.from(new Set(list));
 }
 
-function arraysEqual(a, b) {
-  if (a.length !== b.length) return false;
-  for (let i = 0; i < a.length; i += 1) {
-    if (a[i] !== b[i]) return false;
+function asSortedUnique(list) {
+  return dedupe(list).sort((a, b) => a.localeCompare(b));
+}
+
+function arraysEqualAsSet(a, b) {
+  const left = asSortedUnique(a);
+  const right = asSortedUnique(b);
+  if (left.length !== right.length) return false;
+  for (let i = 0; i < left.length; i += 1) {
+    if (left[i] !== right[i]) return false;
   }
   return true;
 }
@@ -265,18 +286,60 @@ function buildPlannedContexts({ requiredContexts, workflowContexts, renameSugges
   return dedupe(replaced);
 }
 
+function applyPolicyFilters({ plannedContexts, allowlist, denylist }) {
+  const denied = plannedContexts.filter((ctx) => denylist.has(ctx));
+
+  if (allowlist.size === 0) {
+    return {
+      effectiveContexts: plannedContexts,
+      blockedByAllowlist: [],
+      blockedByDenylist: denied,
+    };
+  }
+
+  const blockedByAllowlist = plannedContexts.filter((ctx) => !allowlist.has(ctx));
+  const effectiveContexts = plannedContexts.filter((ctx) => allowlist.has(ctx));
+
+  return {
+    effectiveContexts,
+    blockedByAllowlist,
+    blockedByDenylist: denied,
+  };
+}
+
+function ensureDirFor(filePath) {
+  const dir = path.dirname(filePath);
+  fs.mkdirSync(dir, { recursive: true });
+}
+
+function writeAuditArtifact(filePath, payload) {
+  ensureDirFor(filePath);
+  fs.writeFileSync(filePath, `${JSON.stringify(payload, null, 2)}\n`, 'utf8');
+}
+
 function printSummary(report) {
-  console.log('=== Required-check Context Drift Guard + Auto-remediation (RLOOP-059) ===');
+  console.log('=== Required-check Context Drift Governance Guard (RLOOP-060) ===');
   console.log(`Repo: ${report.owner}/${report.repo}`);
   console.log(`Branch: ${report.branch}`);
   console.log(`Mode: ${report.mode}`);
   console.log(`Canonical only: ${report.canonicalOnly ? 'yes' : 'no'}`);
+  console.log(`Audit file: ${report.auditFile}`);
 
   console.log(`\nRequired contexts (${report.requiredContexts.length})`);
   report.requiredContexts.forEach((ctx) => console.log(`  - ${ctx}`));
 
   console.log(`\nWorkflow/job contexts (${report.workflowContexts.length})`);
   report.workflowContexts.forEach((ctx) => console.log(`  - ${ctx}`));
+
+  if (report.allowlist.length > 0) {
+    console.log(`\nAllowlist (${report.allowlist.length})`);
+    report.allowlist.forEach((ctx) => console.log(`  - ${ctx}`));
+  }
+
+  if (report.denylist.length > 0) {
+    console.log(`\nDenylist (${report.denylist.length})`);
+    report.denylist.forEach((ctx) => console.log(`  - ${ctx}`));
+  }
 
   console.log('\n--- Drift Summary ---');
   if (report.missingInWorkflows.length === 0) {
@@ -307,6 +370,32 @@ function printSummary(report) {
     report.plannedContexts.forEach((ctx) => console.log(`  - ${ctx}`));
   } else {
     console.log('\nPlanned required contexts: no change needed.');
+  }
+
+  if (report.blockedByAllowlist.length > 0) {
+    console.log('\nBlocked by allowlist (removed from effective apply set):');
+    report.blockedByAllowlist.forEach((ctx) => console.log(`  - ${ctx}`));
+  }
+
+  if (report.blockedByDenylist.length > 0) {
+    console.log('\nBlocked by denylist (unsafe for apply):');
+    report.blockedByDenylist.forEach((ctx) => console.log(`  - ${ctx}`));
+  }
+
+  if (report.mode === 'apply') {
+    console.log('\nRead-after-write verification:');
+    console.log(`  - attempted: yes`);
+    console.log(`  - verified: ${report.verified ? 'yes' : 'no'}`);
+    if (!report.verified) {
+      if (report.verificationMissing.length > 0) {
+        console.log('  - missing after apply:');
+        report.verificationMissing.forEach((ctx) => console.log(`      - ${ctx}`));
+      }
+      if (report.verificationUnexpected.length > 0) {
+        console.log('  - unexpected after apply:');
+        report.verificationUnexpected.forEach((ctx) => console.log(`      - ${ctx}`));
+      }
+    }
   }
 
   console.log('\nExecution summary:');
@@ -396,9 +485,32 @@ async function main() {
     canonicalOnly,
   });
 
-  const planChanged = !arraysEqual(requiredContexts, plannedContexts);
+  const allowlist = new Set(toList(args.allowlist));
+  const denylist = new Set(toList(args.denylist));
+
+  const { effectiveContexts, blockedByAllowlist, blockedByDenylist } = applyPolicyFilters({
+    plannedContexts,
+    allowlist,
+    denylist,
+  });
+
+  const planChanged = !arraysEqualAsSet(requiredContexts, effectiveContexts);
+
+  const actor = process.env.GITHUB_ACTOR || process.env.USER || 'unknown';
+  const auditFile = args['audit-file'] || 'artifacts/required-check-drift-audit.json';
 
   let applied = false;
+  let verified = mode !== 'apply';
+  let verifiedContexts = requiredContexts;
+  let verificationMissing = [];
+  let verificationUnexpected = [];
+
+  if (mode === 'apply' && blockedByDenylist.length > 0) {
+    throw new Error(
+      `Apply blocked: ${blockedByDenylist.length} planned context(s) are denylisted. Remove from plan or adjust denylist.`,
+    );
+  }
+
   if (mode === 'apply' && planChanged) {
     try {
       await patchRequiredContexts({
@@ -406,38 +518,72 @@ async function main() {
         repo,
         branch,
         token,
-        contexts: plannedContexts,
+        contexts: effectiveContexts,
         strict,
       });
       applied = true;
     } catch (error) {
       throw new Error(`Failed to patch required contexts: ${error.message}`);
     }
+
+    const verifiedProtection = await fetchBranchProtection({ owner, repo, branch, token });
+    verifiedContexts = extractRequiredContexts(verifiedProtection);
+
+    const expected = asSortedUnique(effectiveContexts);
+    const actual = asSortedUnique(verifiedContexts);
+    verificationMissing = expected.filter((ctx) => !actual.includes(ctx));
+    verificationUnexpected = actual.filter((ctx) => !expected.includes(ctx));
+    verified = verificationMissing.length === 0 && verificationUnexpected.length === 0;
   }
 
   const report = {
+    schemaVersion: 'rloop060.required-check-governance.v1',
+    timestamp: new Date().toISOString(),
+    actor,
+    mode,
     owner,
     repo,
     branch,
-    mode,
     canonicalOnly,
+    auditFile,
     requiredContexts,
     workflowContexts,
     missingInWorkflows,
     extraNotRequired,
     renameSuggestions,
+    allowlist: Array.from(allowlist),
+    denylist: Array.from(denylist),
     plannedContexts,
+    blockedByAllowlist,
+    blockedByDenylist,
+    effectiveContexts,
     planChanged,
     applied,
+    verified,
+    verificationMissing,
+    verificationUnexpected,
+    before: {
+      requiredContexts: requiredContexts,
+    },
+    after: {
+      requiredContexts: mode === 'apply' ? verifiedContexts : requiredContexts,
+    },
   };
 
+  writeAuditArtifact(auditFile, report);
   printSummary(report);
 
   const hasDrift = missingInWorkflows.length > 0 || extraNotRequired.length > 0;
 
   if (mode === 'apply') {
+    if (!verified) {
+      console.error('::error::Read-after-write verification failed.');
+      console.error('::error::Action: rerun in --dry-run to inspect plan, then retry apply; check branch protection admin restrictions and token scopes.');
+      process.exit(1);
+    }
+
     if (planChanged && applied) {
-      console.log('\nResult: APPLIED (required contexts patched).');
+      console.log('\nResult: APPLIED + VERIFIED (required contexts patched and verified).');
       process.exit(0);
     }
 
@@ -460,6 +606,6 @@ async function main() {
 }
 
 main().catch((error) => {
-  console.error(`::error::Unexpected failure in RLOOP-059 guard: ${error.message}`);
+  console.error(`::error::Unexpected failure in RLOOP-060 guard: ${error.message}`);
   process.exit(1);
 });


### PR DESCRIPTION
## Summary
- add governance-grade audit artifact output for required-check drift plans/results
- add read-after-write verification for apply mode with actionable mismatch output
- add allowlist/denylist policy safety and retain explicit apply mode
- wire CI detect/audit artifact upload and update branch protection runbook + rollback path

## Validation
- yarn lint *(fails in this environment: eslint permission denied)*
- yarn typecheck *(pass)*